### PR TITLE
fix: ensure v is prefixed fixes #3

### DIFF
--- a/ver.js
+++ b/ver.js
@@ -139,7 +139,7 @@ async function main() {
 
   if (!args["no-git"]) {
     // create git commit and tag
-    const tagName = args["prefix"] ? `v${newVersion}` : newVersion;
+    const tagName = args["prefix"] ? newVersion : `v${newVersion}`;
     try {
       await run("git", ["commit", "-a", "-m", newVersion]);
       await run("git", ["tag", "-f", "-m", tagName, tagName]);


### PR DESCRIPTION
Turns out this makes -p work.

Tested in GHD locally 

```
~\github\GitHub-Dark-Upstream [master ↑1]> git verify-tag 1.21.31
error: tag '1.21.31' not found.
~\github\GitHub-Dark-Upstream [master ↑1]> git verify-tag v1.21.31
gpg: Signature made 04/07/19 15:35:31 GMT Summer Time
gpg:                using ECDSA key E844918DBF83EF1A97DA6963D2C66BF0E5B3B1D6
gpg: Good signature from "the-j0k3r <31389848+the-j0k3r@users.noreply.github.com>" [ultimate]
~\github\GitHub-Dark-Upstream [master ↑1]>

```